### PR TITLE
addition literature reference, DataWarrior a vector of distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Please add the reference mentioned above if you use Tautobase in your
 study.
 
 For questions/comments, please contact the corresponding author of the
-article.
+article, Oya Wahl <oyawahl@gmail.com>.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
 # Tautobase
-This repository contains relevant project files of publicly available tautomer database "Tautobase". Each tautomer pair in the database has matching atom positions. The first version of the database contains 1680 unique tautomer pairs and available both as a DataWarrior file (.dwar) and a text file containing SMIRKS transformations along with the non-structural information.
+This repository contains relevant project files of the public tautomer
+database "Tautobase", an optional plugin for
+[DataWarrior](http://openmolecules.org/datawarrior/index.html).  It was
+presented in the publication "Tautobase: An Open Tautomer Database",
+Wahl, O. and Sander T. _J. Chem. Inf. Model._ 2020, 60, 1085-1089;
+[doi 10.1021/acs.jcim.0c00035](https://doi.org/10.1021/acs.jcim.0c00035).
+
+The principle source of information digitized in Tautobase is the
+tautomer codex authored by P.W. Kenny and P.J. Taylor, “The Prediction of
+Tautomer Preference in Aqueous Solution”
+(https://doi.org/10.6084/m9.figshare.8966276.v1).
+
+Each tautomer pair in the database has matching atom positions. The first
+version of the database contains 1680 unique tautomer pairs and available
+both as a DataWarrior file (`.dwar`) and a text file containing SMIRKS
+transformations along with the non-structural information.
+
+The list of references, mentioned in the column "Reference" in the `.dwar`
+file equally is provided by this repository.
+
+Tautobase (`.dwar` file and SMIRKS transformations) can be downloaded from
+https://github.com/WahlOya/Tautobase.git
+
+Please add the reference mentioned above if you use Tautobase in your
+study.
 
 
-The information digitalized in Tautobase is mainly sourced from the tautomer codex authored by P.W. Kenny and P.J. Taylor, “The Prediction of Tautomer Preference in Aqueous Solution”. (https://doi.org/10.6084/m9.figshare.8966276.v1)
-
-
-Tautobase (.dwar file and SMIRKS transformations) can be downloaded from https://github.com/WahlOya/Tautobase.git
-
-
-List of references, mentioned in the column "Reference" in the .dwar file can also be downloaded from this repository.
-
-
-If you use Tautobase in your study, for citation please use: DOI
-
-
-For questions/comments, please contact the corresponding author of the article.
+For questions/comments, please contact the corresponding author of the
+article.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ database "Tautobase", an optional plugin for
 presented in the publication "Tautobase: An Open Tautomer Database",
 Wahl, O. and Sander T. _J. Chem. Inf. Model._ 2020, 60, 1085-1089;
 [doi 10.1021/acs.jcim.0c00035](https://doi.org/10.1021/acs.jcim.0c00035).
+Since release February 2020, the installation of DataWarrior (release 2.5.1)
+includes this data base as one of its reference files.
 
 The principle source of information digitized in Tautobase is the
 tautomer codex authored by P.W. Kenny and P.J. Taylor, “The Prediction of
@@ -19,7 +21,8 @@ transformations along with the non-structural information.
 The list of references, mentioned in the column "Reference" in the `.dwar`
 file equally is provided by this repository.
 
-Tautobase (`.dwar` file and SMIRKS transformations) can be downloaded from
+Tautobase (`.dwar` file and SMIRKS transformations) can be downloaded
+separately from DataWarrior at 
 https://github.com/WahlOya/Tautobase.git
 
 Please add the reference mentioned above if you use Tautobase in your

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Tautobase
+
 This repository contains relevant project files of the public tautomer
 database "Tautobase", an optional plugin for
 [DataWarrior](http://openmolecules.org/datawarrior/index.html).  It was
@@ -11,7 +12,7 @@ includes this data base as one of its reference files.
 The principle source of information digitized in Tautobase is the
 tautomer codex authored by P.W. Kenny and P.J. Taylor, “The Prediction of
 Tautomer Preference in Aqueous Solution”
-(https://doi.org/10.6084/m9.figshare.8966276.v1).
+(<https://doi.org/10.6084/m9.figshare.8966276.v1>).
 
 Each tautomer pair in the database has matching atom positions. The first
 version of the database contains 1680 unique tautomer pairs and available
@@ -22,12 +23,11 @@ The list of references, mentioned in the column "Reference" in the `.dwar`
 file equally is provided by this repository.
 
 Tautobase (`.dwar` file and SMIRKS transformations) can be downloaded
-separately from DataWarrior at 
-https://github.com/WahlOya/Tautobase.git
+separately from DataWarrior at
+<https://github.com/WahlOya/Tautobase.git>
 
 Please add the reference mentioned above if you use Tautobase in your
 study.
-
 
 For questions/comments, please contact the corresponding author of the
 article.


### PR DESCRIPTION
This pull request joins the _suggestions_ to add the original literature reference and the note of DataWarrior (release 2.5.1, Feburary 2020) as an additional vector of distribution of `tautobase.dwar`